### PR TITLE
Changed to use AES-CBC with HMAC-SHA1, rather than plain Blowfish ECB

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -5,19 +5,32 @@ import smtplib
 import string
 import time
 import zlib
+import Crypto
 from Crypto import Random
-from Crypto.Cipher import Blowfish
+from Crypto.Cipher import AES
+from Crypto.Hash import HMAC
 from Crypto.Hash import SHA
 from Crypto.Random import random
+from pbkdf2 import PBKDF2
 from email.mime.text import MIMEText
 from flask import Flask, render_template, request, redirect, url_for
 from threading import Thread
 
 # BEGIN CHANGEME.
-key = "cN7RPiuMhJwX1e9MUwuTXggpK9r2ym" # Should be at least 16 bytes long.
 fromaddr = "no-reply@example.com"
 fullname = "John Doe"
+salt1 = "52f9a7242412eed8d607f80a4a97d41b" # Output from Random.new().read(16).encode("hex")
+salt2 = "a79f3ab9732cb999afec457267e49fea"
+
 # END CHANGEME.
+
+
+# SOME CONSTANTS
+FILE_NAME_LENGTH = 16 # number of bytes of randomness for file names
+BLOCK_SIZE = 16 # for AES128 
+MAC_SIZE = 20 # for HMAC-SHA1
+DURESS_TEXT = "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+
 
 dnote = Flask(__name__)
 here = dnote.root_path
@@ -94,55 +107,99 @@ def verify_hashcash(token):
         else:
             return False
 
-def note_encrypt(key, plaintext, new_url, key_file):
+def note_encrypt(key, mac_key, plaintext, fname, key_file):
     """Encrypt a plaintext to a URI file.
 
-    All files are encrypted with Blowfish in ECB mode. Plaintext is
-    compressed with ZLIB first before encryption to prevent leaking
-    repeated blocks in the ciphertext. Also saves disk space.
+    All files are encrypted with AES in CBC mode. HMAC-SHA1 is used
+    to provide authenticated encryption ( encrypt then mac ). No private keys are stored 
+    on the server
 
     Keyword arguments:
-    key -- private key to encrypt the plaintext
+    key -- aes private key to encrypt the plaintext
+    hmac_key -- hmac-sha1 key for authenticated encryption
     plaintext -- the message to be encrypted
-    new_url -- file to save the encrypted text to
-    key_file -- 'True' only if a private key was used for encryption
+    fname -- file to save the encrypted text to
     """
-    pad = lambda s: s + (8 - len(s) % 8) * chr(8 - len(s) % 8)
-    plain = pad(zlib.compress(plaintext.encode('utf-8')))
+    pad = lambda s: s + (BLOCK_SIZE - len(s) % BLOCK_SIZE) * chr(BLOCK_SIZE - len(s) % BLOCK_SIZE)
+    plain = pad(plaintext.encode('utf-8'))
     if key_file:
         # create empty file with '.key' as an extension
-        open('%s/data/%s.key' % (here, new_url), 'a').close()
-    with open('%s/data/%s' % (here,new_url), 'w') as f:
-        bf = Blowfish.new(key, Blowfish.MODE_ECB)
-        ciphertext = bf.encrypt(plain)
+        open('%s/data/%s.key' % (here, fname), 'a').close()
+    with open('%s/data/%s' % (here,fname), 'w') as f:
+        iv = Random.new().read(BLOCK_SIZE)
+        aes = AES.new(key, AES.MODE_CBC, iv)
+        ciphertext = aes.encrypt(plain)
+        ciphertext = iv + ciphertext
+        # generate a hmac tag
+        hmac=HMAC.new(mac_key,ciphertext,Crypto.Hash.SHA)
+        ciphertext = hmac.digest() + ciphertext
         f.write(ciphertext.encode("base64"))
 
-def note_decrypt(key, ciphertext):
-    """Decrypt a ciphertext from a given URI file.
+def note_decrypt(key, mac_key, fname):
+    """Decrypt the ciphertext from a given URI file.
 
     Keyword arguments:
-    key -- private key to decrypt the ciphertext
-    ciphertext -- the message to be decrypted
+    key -- aes private key to decrypt the plaintext
+    hmac_key -- hmac-sha1 key for authenticated encryption
+    fname -- filename containing the message to be decrypted
     """
+    
     unpad = lambda s : s[0:-ord(s[-1])]
-    with open('%s/data/%s' % (here, ciphertext), 'r') as f:
+    with open('%s/data/%s' % (here, fname), 'r') as f:
         message = f.read()
-    bf = Blowfish.new(key, Blowfish.MODE_ECB)
-    plaintext = bf.decrypt(message.decode("base64"))
-    return zlib.decompress(unpad(plaintext)).decode('utf-8')
+    message = message.decode("base64")
+    tag = message[:MAC_SIZE]
+    data = message[MAC_SIZE:]
+    iv = data[:BLOCK_SIZE]
+    body = data[BLOCK_SIZE:]
+    aes = AES.new(key, AES.MODE_CBC,iv)
+    plaintext = aes.decrypt(body)
+    # check the message tags, return 0 if is good 
+    # constant time comparison
+    tag2 = HMAC.new(mac_key,data,Crypto.Hash.SHA).digest()
+    hmac_check = 0
+    for x, y in zip(tag, tag2):
+        hmac_check |= ord(x) ^ ord(y)
+    return hmac_check,unpad(plaintext).decode('utf-8')
 
 def create_url():
-    """Return a new random 128-bit URI for retrieval."""
-    new_url = base64.urlsafe_b64encode(Random.new().read(16))[:22]
-    if os.path.exists('%s/data/%s' % (here, new_url)):
+    """Generate enough randomness for filename, aes key, mac key.
+     
+    128 bits for file name
+    128 bits for AES-128 key
+    160 bits for HMAC-SHA1 key      
+  
+    and encode it into 70byte URI
+    """
+    uri_rand=Random.new().read(52) 
+    fname = base64.urlsafe_b64encode(uri_rand[:16])[:22]
+    key = uri_rand[16:32] # 16 bytes for AES key
+    mac_key = uri_rand[32:] # 20 bytes for HMAC
+    if os.path.exists('%s/data/%s' % (here, fname)):
         create_url()
-    return new_url
+    # remove the last 2 "==" from the url
+    new_url = base64.urlsafe_b64encode(uri_rand)[:70]
+    return {"new_url": new_url, "key": key, "mac_key": mac_key, "fname": fname}
+
+def decode_url(url):
+    """ 
+    Takes a url, and returns the fname, key, hmac_key out of it
+    """
+    # add the padding back
+    url = url + "=="
+    uri_rand = base64.urlsafe_b64decode(url.encode("utf-8"))
+    fname = base64.urlsafe_b64encode(uri_rand[:16])[:22]
+    key = uri_rand[16:32] # 16 bytes for AES key
+    mac_key = uri_rand[32:] # 20 bytes for HMAC
+    return {"key": key, "mac_key": mac_key, "fname":fname}
+
+ 
 
 @dnote.route('/', methods = ['GET'])
 def index():
     """Return the index.html for the main application."""
     error = None
-    new_url = create_url()
+    new_url = create_url()["new_url"]
     return render_template('index.html', random = new_url, error=error)
 
 @dnote.route('/security/', methods = ['GET'])
@@ -166,76 +223,98 @@ def show_post(new_url):
     
     Keyword arguments:
     new_url -- encrypted file representing the unique URL
+    if a user provided string is used for key generation
+    use PBKDF2 to generate secure keys from it.
     """
+    url_data=decode_url(new_url)
+    key = url_data["key"]
+    mac_key = url_data["mac_key"]
+    fname = url_data["fname"]
     if request.method == 'POST':
         plaintext = request.form['paste']
         token = request.form['hashcash']
         valid_token = verify_hashcash(token)
         if request.form.get('duress', False) and request.form['pass'] and valid_token:
-            dkey = duress_key(new_url)
-            privkey = request.form['pass']
+            dkey = duress_key(fname)
+            passphrase = request.form['pass']
+            key = PBKDF2(passphrase, salt1.decode("hex")).read(16)
+            mac_key = PBKDF2(passphrase, salt2.decode("hex")).read(20)
             key_file = True
-            note_encrypt(privkey, plaintext, new_url, key_file)
-            return render_template('post.html', random=new_url, privkey=privkey, duress=dkey)
+            note_encrypt(key, mac_key, plaintext, fname, key_file)
+            return render_template('post.html', random=new_url, passphrase=passphrase, duress=dkey)
         elif request.form['pass'] and valid_token:
-            privkey = request.form['pass']
+            passphrase = request.form['pass']
+            key = PBKDF2(passphrase, salt1.decode("hex")).read(16)
+            mac_key = PBKDF2(passphrase, salt2.decode("hex")).read(20)
             key_file = True
-            note_encrypt(privkey, plaintext, new_url, key_file)
-            return render_template('post.html', random=new_url, privkey=privkey)
+            note_encrypt(key, mac_key, plaintext, fname, key_file)
+            return render_template('post.html', random=new_url, passphrase=passphrase)
         elif not request.form['pass'] and valid_token:
             key_file = False
-            note_encrypt(key, plaintext, new_url, key_file)
+            note_encrypt(key, mac_key, plaintext, fname, key_file)
             return render_template('post.html', random=new_url)
 
 @dnote.route('/<random_url>', methods = ['POST', 'GET'])
 def fetch_url(random_url):
     """Return the decrypted note. Begin short destruction timer.
     
-    Only 1 person should be able to view the note, even if the not has not yet
-    been destroyed. As such, a lock file is created when the note is read, to
-    prevent anyone else from also viewing it. A standard 404 error is thrown,
-    as to not give any hints as to whether or not the note still exists.
-    
     Keyword arguments:
     random_url -- Random URL representing the encrypted note
     """
-    if not os.path.exists('%s/data/%s' % (here,random_url)):
+    url_data=decode_url(random_url)
+    key = url_data["key"]
+    mac_key = url_data["mac_key"]
+    fname = url_data["fname"]
+
+    if not os.path.exists('%s/data/%s' % (here,fname)):
         return render_template('404.html'), 404
-    elif os.path.exists('%s/data/%s.key' % (here,random_url)) and request.method != 'POST':
+    elif os.path.exists('%s/data/%s.key' % (here,fname)) and request.method != 'POST':
         return render_template('key.html', random = random_url)
-    elif os.path.exists('%s/data/%s.key' % (here,random_url)) and request.method == 'POST':
-        privkey = request.form['pass']
-        if os.path.exists('%s/data/%s.dkey' % (here,random_url)):
-            with open('%s/data/%s.dkey' % (here,random_url), 'r') as f:
-                if privkey in f:
-                    secure_remove('%s/data/%s' % (here, random_url))
-                    secure_remove('%s/data/%s.key' % (here, random_url))
-                    secure_remove('%s/data/%s.dkey' % (here, random_url))
-                    return render_template('404.html'), 404
+    elif os.path.exists('%s/data/%s.key' % (here,fname)) and request.method == 'POST':
+        passphrase = request.form['pass']
+        key = PBKDF2(passphrase, salt1.decode("hex")).read(16)
+        mac_key = PBKDF2(passphrase, salt2.decode("hex")).read(20)
+        if os.path.exists('%s/data/%s.dkey' % (here,fname)):
+            with open('%s/data/%s.dkey' % (here,fname), 'r') as f:
+                if passphrase in f:
+                    secure_remove('%s/data/%s' % (here, fname))
+                    secure_remove('%s/data/%s.key' % (here, fname))
+                    secure_remove('%s/data/%s.dkey' % (here, fname))
+                    # return render_template('404.html'), 404
+                    return render_template('note.html', text = DURESS_TEXT)
                 else:
                     try:
-                        plaintext = note_decrypt(privkey, random_url)
-                        secure_remove('%s/data/%s' % (here, random_url))
-                        secure_remove('%s/data/%s.key' % (here, random_url))
-                        if os.path.exists('%s/data/%s.dkey' % (here, random_url)):
-                            secure_remove('%s/data/%s.dkey' % (here, random_url))
-                        return render_template('note.html', text = plaintext)
+                        hmac_check,plaintext = note_decrypt(key, mac_key, fname)
+                        if hmac_check != 0 :
+                            return render_template('keyerror.html', random=random_url)
+                        else: 
+                            secure_remove('%s/data/%s' % (here, fname))
+                            secure_remove('%s/data/%s.key' % (here, fname))
+                            if os.path.exists('%s/data/%s.dkey' % (here, fname)):
+                                secure_remove('%s/data/%s.dkey' % (here, fname))
+                            return render_template('note.html', text = plaintext)
                     except:
                         return render_template('keyerror.html', random=random_url)
         else:
             try:
-                plaintext = note_decrypt(privkey, random_url)
-                secure_remove('%s/data/%s' % (here, random_url))
-                secure_remove('%s/data/%s.key' % (here, random_url))
-                if os.path.exists('%s/data/%s.dkey' % (here, random_url)):
-                    secure_remove('%s/data/%s.dkey' % (here, random_url))
-                return render_template('note.html', text = plaintext)
+                hmac_check,plaintext = note_decrypt(key, mac_key, fname)
+                if hmac_check != 0 :
+                    return render_template('keyerror.html', random=random_url)
+                else: 
+                    secure_remove('%s/data/%s' % (here, fname))
+                    secure_remove('%s/data/%s.key' % (here, fname))
+                    if os.path.exists('%s/data/%s.dkey' % (here, fname)):
+                        secure_remove('%s/data/%s.dkey' % (here, fname))
+                    return render_template('note.html', text = plaintext)
             except:
                 return render_template('keyerror.html', random=random_url)
     else:
-        plaintext = note_decrypt(key, random_url)
-        secure_remove('%s/data/%s' % (here, random_url))
-        return render_template('note.html', text = plaintext)
+        hmac_check,plaintext = note_decrypt(key, mac_key, fname)
+        if hmac_check != 0 :
+            return render_template('404.html'), 404
+        else:
+            secure_remove('%s/data/%s' % (here, fname))
+            return render_template('note.html', text = plaintext)
 
 if __name__ == '__main__':
     dnote.debug = True

--- a/templates/post.html
+++ b/templates/post.html
@@ -16,9 +16,9 @@
     it now</a>.</p>
     <p>Your private url:<br/>
     <input id="note" size="40" readonly="readonly" type="text" value="{{ url_for('fetch_url', random_url=random, _external=True) }}"/></p>
-    {% if privkey %}
-    <p>Your private  key:<br/>
-    <input size="40" readonly="readonly" type="text" value="{{ privkey }}"/></p>
+    {% if passphrase %}
+    <p>Your passphrase:<br/>
+    <input size="40" readonly="readonly" type="text" value="{{ passphrase }}"/></p>
     {% endif %}
     {% if duress %}
     <p>Your duress key:<br/>


### PR DESCRIPTION
Changed to use AES-CBC with HMAC-SHA1, rather than plain Blowfish ECB
for authenticated encryption and associated data ( encrypt then mac )

Server never records the encryption keys now, the url contains the
decryption keys, unless a user passphrase is used.

User passphrases are passed through PBKDF2 for improved entropy.

Duress key provides lorem ipsum text.
