### PR TITLE
Validation bugfixes and error handling

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -17,6 +17,10 @@ function validate_form() {
         alert("You need to enter a message.");
         return false;
     }
+    else if (document.getElementById('duress').checked && document.getElementById('passphrase').value == "") {
+        alert("You need to enter a passphrase if you enable a duress key");
+        return false;
+    }
     else {
         please_wait();
         setTimeout(function(){},0);

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,6 +14,15 @@
     <h1>Self destructing encrypted notes</h1>
     <form method="POST" onsubmit="return validate_form()" action="{{
     url_for('show_post', new_url=random, _external=True) }}">
+        {% if error %}
+            <p class="error">
+            {% if error == "hashcash" %}
+                HashCash token is invalid. Please make sure JavaScript is enabled and try again.
+            {% elif error == "duress" %}
+                You must specify a passphrase if you enable the use of a duress key.
+            {% endif %}
+            </p>
+        {% endif %}
         <p>Paste your secret note here!</p>
         <textarea style="width:100%; height:250px" id="paste"
         name="paste"></textarea>
@@ -23,7 +32,7 @@
         <input type="button" value="Generate"
         onclick="document.getElementById('passphrase').value = make_key()">
         <br/>
-        <input type="checkbox" name="duress">Add a duress key.
+        <input type="checkbox" id="duress" name="duress">Add a duress key.
         <span class="tooltip" title="A  key that you provide to someone that is
         demanding decryption of the note. Except, this key will immediately
         destroy the note, without decrypting it.">&nbsp;?&nbsp;</span>


### PR DESCRIPTION
- Fix bug in verify_hashcash to search db for the token, not the digest.
- Streamline if logic in show_post.
- Add error reporting for missing/invalid hashcash token.
- Add error reporting for missing passphrase when duress is enabled.
- Add template, js, css necessary to display errors.
