### PR TITLE
Moving URL generation from client to server

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -215,6 +215,15 @@ without deleting the hashcash.db file:
 5 0     * * *   root    find /var/lib/dnote/data/* \( -iname "*" ! -iname "hashcash.db" \) -mtime +30 -exec rm {} \;
 
 
+IPTables flood/(D)DoS/bruteforce protection
+-------------------------------------------
+
+iptables -A INPUT -s 0.0.0.0/0 -d 0.0.0.0/0 -p tcp --syn --dport 80 -m connlimit --connlimit-above 20 -j LOGGING
+iptables -A INPUT -s 0.0.0.0/0 -d 0.0.0.0/0 -p tcp --syn --dport 443 -m connlimit --connlimit-above 20 -j LOGGING
+iptables -A LOGGING -m limit --limit 2/min -j LOG --log-prefix "iptables-http-connlimit: " --log-level 4
+iptables -A LOGGING -p tcp -j REJECT --reject-with tcp-reset
+
+
 Troubleshooting
 ---------------
 If you are getting any internal service errors make sure to verify that the

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -206,6 +206,15 @@ the following to your sites config (again, you can tweak thsi as needed):
 And tada, restart the Nginx server and you should have a working dnote setup.
 
 
+cronjob for removing old notes
+------------------------------
+
+Add the following to /etc/crontab to automatically delete old Notes (30 days)
+without deleting the hashcash.db file:
+
+5 0     * * *   root    find /var/lib/dnote/data/* \( -iname "*" ! -iname "hashcash.db" \) -mtime +30 -exec rm {} \;
+
+
 Troubleshooting
 ---------------
 If you are getting any internal service errors make sure to verify that the

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -55,31 +55,100 @@ Now configure Apache to server the application. Create
 that you serve the application over SSL. See additional Apache documentation as
 necessary.
 
-    <Virtualhost *:443>
-        DocumentRoot /var/www/
-        CustomLog /var/log/apache2/access.log combined
-        ServerName www.example.com
-        ServerAlias www.example.com example.com
-        ServerAdmin webmaster@example.com
-        <Directory /var/www/>
-            Options -Indexes FollowSymLinks
-        </Directory>
-        WSGIScriptAlias / /var/www/dnote.wsgi
-        <Directory /var/www/dnote/
-            Order allow,deny
-            Allow from all
-        </Directory>
-            Alias /d/static /var/www/dnote/static
-        <Directory /var/www/dnote/static/>
-            Order allow,deny
-            Allow from all
-        </Directory>
+Notes:
+ - Change <www.yourwebsite.tld> to your own URL.
+ - Logs changed to only contain method, not the actualy request to avoid logging Note URLs in local logs
+ - Secure headers
+ - Replace <www.yourotherwebsite.tld> with your own second public URL
+ - Set your own public public cert, private key and intermediate CA file paths
+ - Fix 404 is to make sure a template error message will get used in those conditions
+ - "## Deny access" can be used to limit those who can store a Note
 
-        SSLEngine on
-        SSLCertificateFile /etc/ssl/certs/www_example_com.crt
-        SSLCertificateKeyFile /etc/ssl/private/www_example_com.key
-        SSLHonorCipherOrder On
-    </VirtualHost>
+<Virtualhost *:80>
+    Redirect permanent / https://<www.yourwebsite.tld>/
+</VirtualHost>
+
+<Virtualhost *:443>
+    DocumentRoot /var/www/
+    ServerName <www.yourwebsite.tld>
+    ServerAdmin webmaster@<www.yourwebsite.tld>
+
+    LogFormat "%h %l %u %t \"%m\" %>s %O \"%{User-Agent}i\"" securelog
+    CustomLog /var/log/apache2/access.log securelog
+
+    Header always edit Set-Cookie ^(.*)$ $1;secure
+    Header always set X-Frame-Options "DENY"
+    Header always set X-XSS-Protection "1; mode=block"
+    Header always set Strict-Transport-Security "max-age=315360000; includeSubDomains; preload"
+    Header always set X-Content-Type-Options "nosniff"
+    Header always set X-Permitted-Cross-Domain-Policies "none"
+
+    <Directory /var/www/>
+        Options -Indexes +FollowSymLinks
+    </Directory>
+
+    WSGIScriptAlias / /var/www/dnote.wsgi
+
+    <Directory /var/www/dnote/>
+        Order allow,deny
+        Allow from all
+    </Directory>
+
+        Alias /d/static /var/www/dnote/static
+
+    <Directory /var/www/dnote/static/>
+        Order allow,deny
+        Allow from all
+    </Directory>
+
+    # In case you want to limit access
+    <Location />
+        #order deny,allow
+        #deny from all
+        #allow from 127.0.0.1
+    </Location>
+
+    ## In case you want to limit specific access
+    #<Location ~ "/.+">
+    #    order deny,allow
+    #    allow from all
+    #</Location>
+
+    # Enable rewriteEngine
+    RewriteEngine On
+
+    # Redirect IP based requests to hostname
+    RewriteCond %{HTTP_HOST} !^<www.yourwebsite.tld>$
+    RewriteRule /.* https://<www.yourwebsite.tld>/ [R]
+
+    ## Deny access to parts where data is entered
+    ## Redirect Internet users from / to public website
+    #RewriteCond "%{REMOTE_ADDR}" "!=127.0.0.1"
+    #RewriteCond "%{REQUEST_URI}" "^/$"          [OR]
+    #RewriteCond "%{REQUEST_URI}" "^/post$"      [OR]
+    #RewriteCond "%{REQUEST_URI}" "^/about/$"    [OR]
+    #RewriteCond "%{REQUEST_URI}" "^/security/$" [OR]
+    #RewriteCond "%{REQUEST_URI}" "^/faq/$"
+    #RewriteRule "^/(.*)$" "https://<www.yourotherwebsite.tld>/" [R,L]
+
+    # Fix 404
+    RewriteCond "%{REQUEST_URI}" "!^/post$"
+    RewriteCond "%{REQUEST_URI}" "!^/about/$"
+    RewriteCond "%{REQUEST_URI}" "!^/security/$"
+    RewriteCond "%{REQUEST_URI}" "!^/faq/$"
+    RewriteCond "%{REQUEST_URI}" "^/.*/$"
+    RewriteRule "^/(.*)$" "https://<www.yourwebsite.tld>/error" [R,L]
+
+    # Enable and configure SSL
+    SSLEngine               on
+    SSLProtocol             all -SSLv2 -SSLv3 -TLSv1 -TLSv1.1
+    SSLCipherSuite          EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH
+    SSLHonorCipherOrder     on
+    SSLCertificateFile      /etc/apache2/ssl/your_public_cert.crt
+    SSLCertificateKeyFile   /etc/apache2/ssl/your_private_key.key
+    SSLCertificateChainFile /etc/apache2/ssl/ca_intermediate_certificates.pem
+</VirtualHost>
+
 
 Restart Apache, and verify that the site loads:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 d-note
 ======
 
+Fork information
+================
+This is a fork of atoponce/d-note because it was not being maintained.
+I have made several changes to securely run this as a company service.
+
+The changes / commits will be added shortly
+
+ With kind regards,
+     Thijssss
+
 Background
 ----------
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,23 @@ d-note
 Fork information
 ================
 This is a fork of atoponce/d-note because it was not being maintained.
-I have made several changes to securely run this as a company service.
+I have made several changes to securely run this as a company service:
 
-The changes / commits will be added shortly
+ - IPTables bruteforce protection
+ - Generate URL (Note ID) on server, not by the client
+ - Improved Apache configuration
+   - Adjusted Logging using LogFormat to not log the actual request; otherwise it would leak URL (Note ID) information in logs.
+     These could actually be used if for example a Note was requested with a wrong password.
+   - End security related headers
+   - Rewrite IP based requests to actual hostname to match TLS certificate
+   - Make it possible to separate access between being able to POST a Note and to READ a note
+   - Rewrite certain requests so the program uses the 404 error template instead of Apache giving an error
+   - Improve SSL configuration
+ - Added ASCII input validation on hashcash input
+ - Added crontab information to delete old notes (30 days)
+ - Added input validation on URL to avoid Apache 500 errors caused by padding problem with invalid, too long or short URLs
+
+See the Wiki for more information.
 
  With kind regards,
      Thijssss

--- a/dnote/__init__.py
+++ b/dnote/__init__.py
@@ -1,6 +1,8 @@
 """This module sets up the paths for the Flask web application."""
 import os
 import utils
+import random
+import string
 from flask import Flask, render_template, request, redirect, url_for
 from note import Note
 
@@ -32,8 +34,23 @@ def about():
 @DNOTE.route('/post', methods=['POST'])
 def show_post():
     """Return the random URL after posting the plaintext."""
-    new_url = request.form["new_url"]
+    # Generate URL server-side    
+    min_char = 16
+    max_char = 25
+    allchar = string.ascii_letters + string.digits
+    new_url = "".join(random.SystemRandom().choice(allchar) for x in range(random.randint(min_char, max_char)))
+
+    # Create Note object
     note = Note(new_url)
+
+    # Check to avoid overwriting existing Note, regenerate if necessary - sorry hardcoded data_dir path for now
+    data_dir = "/var/lib/dnote/data/"
+    pathFilename = data_dir + note.fname
+    while os.path.isfile(pathFilename):
+       new_url = "".join(random.SystemRandom().choice(allchar) for x in range(random.randint(min_char, max_char)))
+       note = Note(new_url)
+       pathFilename = data_dir + note.fname
+
     note.plaintext = request.form['paste']
 
     passphrase = request.form.get('pass', False)

--- a/dnote/note.py
+++ b/dnote/note.py
@@ -108,8 +108,14 @@ class Note(object):
 
         self.url = url
         url = url + "==" # add the padding back
-        self.nonce = base64.urlsafe_b64decode(url.encode("utf-8"))
-        self.f_key = KDF.PBKDF2(
+
+	try:
+	        self.nonce = base64.urlsafe_b64decode(url.encode("utf-8"))
+	except:
+		url = "errormessage=="
+		self.nonce = base64.urlsafe_b64decode(url.encode("utf-8"))
+
+	self.f_key = KDF.PBKDF2(
             self.nonce, dconfig.nonce_salt.decode("hex"), 16)
         self.aes_key = KDF.PBKDF2(
             self.nonce, dconfig.aes_salt.decode("hex"), 32)

--- a/dnote/templates/index.html
+++ b/dnote/templates/index.html
@@ -19,7 +19,6 @@
             {% endif %}
             </p>
         {% endif %}
-        <input name="new_url" type="hidden" value="{{ random }}">
         <p>Type or paste your text below:</p>
         <textarea style="width:100%; height:250px" id="paste" name="paste"></textarea>
         <br/>

--- a/dnote/utils.py
+++ b/dnote/utils.py
@@ -26,6 +26,11 @@ def verify_hashcash(token):
     Keyword arguments:
     token -- a proposed Hashcash token to validate."""
 
+    try:
+        token.decode('ascii')
+    except:
+        return False
+
     digest = SHA.new(token)
     with open('%s/hashcash.db' % data_dir, 'a+') as database:
         if digest.hexdigest()[:4] == '0000' and token not in database.read():


### PR DESCRIPTION
This is my first attempt at a pull request, not sure how this will work.
Anyway, I have a commit in my fork repo which moves the URL creation (Note ID generation) from the client to the server side. This is more secure because there is less client input being processed. Also, with the ID generation on the client side it was possible to make up URLs like robot.txt and such and also to overwrite existing notes. Also on the server side you can avoid note URL collisions.