### PR TITLE
Sign form data to ensure it is not tampered with

### DIFF
--- a/dnote/templates/index.html
+++ b/dnote/templates/index.html
@@ -19,7 +19,9 @@
             {% endif %}
             </p>
         {% endif %}
-        <input name="new_url" type="hidden" value="{{ random }}">
+        <input name="new_url" type="hidden" value="{{ note.url }}"/>
+        <input name="timestamp" type="hidden" value="{{ note.timestamp }}"/>
+        <input name="signature" type="hidden" value="{{ note.signature }}"/>
         <p>Type or paste your text below:</p>
         <textarea style="width:100%; height:250px" id="paste" name="paste"></textarea>
         <br/>

--- a/dnote/templates/signerror.html
+++ b/dnote/templates/signerror.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% block title %}Signature Error{% endblock %}
+{% block content %}
+    <h1>Error</h1>
+    <p>Your request appears to have been tampered with. Please try again.</p>
+    <p>error: {{ error }}</p>
+{% endblock %}

--- a/scripts/generate_dnote_hashes
+++ b/scripts/generate_dnote_hashes
@@ -45,4 +45,6 @@ if not os.path.exists(dconfig):
         f.write('mac_salt = "%s"\n' % os.urandom(16).encode('hex'))
         f.write('nonce_salt = "%s"\n' % os.urandom(16).encode('hex'))
         f.write('duress_salt = "%s"\n' % os.urandom(16).encode('hex'))
+        f.write('server_secret = "%s"\n' % os.urandom(64).encode('hex'))
+        f.write('signature_validity = 300  # seconds\n')
     os.chmod(dconfig, 0440)


### PR DESCRIPTION
This adds a server secret and uses it to sign the generated url with a
timestamp to prevent client-side tampering.

Needs testing and will break existing installations due to additional configuration options.

fixes #57